### PR TITLE
Add guide on how to build and run alpha server

### DIFF
--- a/alpha/README.md
+++ b/alpha/README.md
@@ -1,0 +1,33 @@
+# alpha-server
+
+The alpha-server works as the pack leader to keep the consistency of transactions.
+For more information, see [saga pack design](https://github.com/apache/incubator-servicecomb-saga/blob/master/docs/design.md)
+
+## Build and Run
+
+### Via docker image
+Build the executable files and docker image:
+```
+mvn clean package -DskipTests -Pdocker -Pdemo
+```
+
+Then play `alpha-server` image with docker, docker-compose or any other container based environment.
+
+You can override the configurations by `JAVA_OPTS` environment variable:
+```
+docker run -d -p 8080:8080 -p 8090:8090 \ 
+-e "JAVA_OPTS=-Dspring.profiles.active=prd -Dspring.datasource.url=jdbc:postgresql://${host_address}:5432/saga?useSSL=false" alpha-server:${saga_version}
+```
+
+
+### Via executable file
+
+Build the executable files:
+```bash
+mvn clean package -DskipTests -Pdemo
+```
+
+And run:
+```
+java -Dspring.profiles.active=prd -D"spring.datasource.url=jdbc:postgresql://${host_address}:5432/saga?useSSL=false" -jar alpha-server-${saga_version}-exec.jar
+```

--- a/saga-demo/booking/README.md
+++ b/saga-demo/booking/README.md
@@ -10,11 +10,13 @@ You will need:
 2. [Maven 3.x][maven]
 3. [Docker][docker]
 4. [Docker compose][docker_compose]
+5. [alpha server][alpha_server]
 
 [jdk]: http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html
 [maven]: https://maven.apache.org/install.html
 [docker]: https://www.docker.com/get-docker
 [docker_compose]: https://docs.docker.com/compose/install/
+[alpha_server]: https://github.com/apache/incubator-servicecomb-saga/tree/master/alpha
 
 ## Running Demo
 You can run the demo using either docker compose or executable files.


### PR DESCRIPTION
Add document on alpha-server and link it to saga-demo document.

Add the README.me file under `alpha/`, describe how to build and run alpha-server, and add links to alpha-server in saga demo's document, making alpha-server as a prerequisite.

I add this because I failed to notice that alpha-server is needed to run saga demo at my first try.