### PR TITLE
SCB-20 Build ServiceComb-Saga with Java

### DIFF
--- a/acceptance-tests/acceptance-pack/pom.xml
+++ b/acceptance-tests/acceptance-pack/pom.xml
@@ -49,6 +49,38 @@
 
   <profiles>
     <profile>
+      <id>jdk9</id>
+      <activation>
+        <jdk>9</jdk>
+      </activation>
+      <!-- TODO using jdk argLine to get rid of the jaxb dependencies -->
+      <properties>
+        <jdk.argLine>--add-modules java.xml.bind</jdk.argLine>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>javax.xml.bind</groupId>
+          <artifactId>jaxb-api</artifactId>
+          <version>${jaxb.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-impl</artifactId>
+          <version>${jaxb.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.glassfish.jaxb</groupId>
+          <artifactId>jaxb-runtime</artifactId>
+          <version>${jaxb.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>javax.activation</groupId>
+          <artifactId>activation</artifactId>
+          <version>${javax.activation.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
       <id>docker</id>
       <build>
         <plugins>
@@ -287,7 +319,7 @@
                   ${info.service.uri}
                 </info.service.uri>
               </systemPropertyVariables>
-              <argLine>${jacoco.failsafe.argLine}</argLine>
+              <argLine>@jacoco.failsafe.argLine</argLine>
             </configuration>
             <executions>
               <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,8 @@
     <eclipse.link.version>2.7.1</eclipse.link.version>
     <jackson.version>2.9.0</jackson.version>
     <byteman.version>4.0.1</byteman.version>
+    <jaxb.version>2.3.0</jaxb.version>
+    <javax.activation.version>1.1.1</javax.activation.version>
     <maven-dependency-plugin.version>3.0.2</maven-dependency-plugin.version>
   </properties>
 


### PR DESCRIPTION
Now Saga can build with Java9 by using the spring-boot-2 profile.