### PR TITLE
[SCB-584] Clear up testing code for Dubbo filter tests

### DIFF
--- a/omega/omega-transport/omega-transport-dubbo/src/test/java/SagaDubboConsumerFilterTest.java
+++ b/omega/omega-transport/omega-transport-dubbo/src/test/java/SagaDubboConsumerFilterTest.java
@@ -17,7 +17,6 @@
 
 import com.alibaba.dubbo.config.spring.extension.SpringExtensionFactory;
 import com.alibaba.dubbo.rpc.Invocation;
-import org.apache.servicecomb.saga.omega.context.IdGenerator;
 import org.apache.servicecomb.saga.omega.context.OmegaContext;
 import org.apache.servicecomb.saga.omega.transport.dubbo.SagaDubboConsumerFilter;
 import org.junit.After;
@@ -38,8 +37,6 @@ public class SagaDubboConsumerFilterTest {
 
   private static final String globalTxId = UUID.randomUUID().toString();
   private static final String localTxId = UUID.randomUUID().toString();
-  @SuppressWarnings("unchecked")
-  private final IdGenerator<String> idGenerator = mock(IdGenerator.class);
 
   private final OmegaContext omegaContext = new OmegaContext(() -> "ignored");
   private final Invocation invocation = mock(Invocation.class);
@@ -48,7 +45,7 @@ public class SagaDubboConsumerFilterTest {
 
   @Before
   public void setUp() {
-    when(idGenerator.nextId()).thenReturn(globalTxId, localTxId);
+    omegaContext.clear();
     when(applicationContext.containsBean("omegaContext")).thenReturn(true);
     when(applicationContext.getBean("omegaContext")).thenReturn(omegaContext);
     SpringExtensionFactory.addApplicationContext(applicationContext);

--- a/omega/omega-transport/omega-transport-dubbo/src/test/java/SagaDubboProviderFilterTest.java
+++ b/omega/omega-transport/omega-transport-dubbo/src/test/java/SagaDubboProviderFilterTest.java
@@ -45,7 +45,6 @@ public class SagaDubboProviderFilterTest {
   @Before
   public void setUp() {
     omegaContext.clear();
-    ApplicationContext applicationContext = mock(ApplicationContext.class);
     when(applicationContext.containsBean("omegaContext")).thenReturn(true);
     when(applicationContext.getBean("omegaContext")).thenReturn(omegaContext);
     SpringExtensionFactory.addApplicationContext(applicationContext);


### PR DESCRIPTION
The IdGenerator is not used thus removed.
Also add omegaContext.clear() in setup to make the tests pass
in linux. But the problem still exists, the filters should use
a better way to get the omegaContext, see SCB-584 for details.

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SCB) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[SCB-XXX] Fixes bug in ApproximateQuantiles`, where you replace `SCB-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
