### PR TITLE
SCB-784 SagaStart should send TxAbortEvent when the exception is thrown

### DIFF
--- a/acceptance-tests/acceptance-pack-dubbo-demo/src/test/resources/AExceptionWhenAb_scenario.feature
+++ b/acceptance-tests/acceptance-pack-dubbo-demo/src/test/resources/AExceptionWhenAb_scenario.feature
@@ -29,8 +29,10 @@ Feature: Alpha records transaction events
       | serviceb    | TxStartedEvent     |
       | serviceb   | TxEndedEvent   |
       | servicea   | TxAbortedEvent     |
+      | servicea   | TxAbortedEvent     |
       | serviceb | TxCompensatedEvent   |
       | * | SagaEndedEvent   |
+
 
     And servicea success update status
       | service | vstatus |

--- a/acceptance-tests/acceptance-pack-dubbo-demo/src/test/resources/BExceptionWhenAb_scenario.feature
+++ b/acceptance-tests/acceptance-pack-dubbo-demo/src/test/resources/BExceptionWhenAb_scenario.feature
@@ -29,7 +29,9 @@ Feature: Alpha records transaction events
       | serviceb    | TxStartedEvent     |
       | serviceb   | TxAbortedEvent   |
       | servicea   | TxAbortedEvent     |
+      | servicea    | TxAbortedEvent     |
       | * | SagaEndedEvent   |
+
 
     And servicea success update status
       | service | vstatus |

--- a/acceptance-tests/acceptance-pack-dubbo-demo/src/test/resources/CExceptionWhenAbAc_scenario.feature
+++ b/acceptance-tests/acceptance-pack-dubbo-demo/src/test/resources/CExceptionWhenAbAc_scenario.feature
@@ -32,8 +32,10 @@ Feature: Alpha records transaction events
       | servicec | TxStartedEvent   |
       | servicec | TxAbortedEvent   |
       | servicea | TxAbortedEvent   |
+      | servicea | TxAbortedEvent   |
       | serviceb | TxCompensatedEvent   |
       | * | SagaEndedEvent   |
+
 
     And servicea success update status
       | service | vstatus |

--- a/acceptance-tests/acceptance-pack-dubbo-demo/src/test/resources/CExceptionWhenAbBc_scenario.feature
+++ b/acceptance-tests/acceptance-pack-dubbo-demo/src/test/resources/CExceptionWhenAbBc_scenario.feature
@@ -32,7 +32,9 @@ Feature: Alpha records transaction events
       | servicec | TxAbortedEvent   |
       | serviceb | TxAbortedEvent   |
       | servicea | TxAbortedEvent   |
+      | servicea | TxAbortedEvent     |
       | * | SagaEndedEvent   |
+
 
     And servicea success update status
       | service | vstatus |

--- a/acceptance-tests/acceptance-pack-spring-demo/src/test/java/org/apache/servicecomb/saga/PackStepdefs.java
+++ b/acceptance-tests/acceptance-pack-spring-demo/src/test/java/org/apache/servicecomb/saga/PackStepdefs.java
@@ -145,7 +145,7 @@ public class PackStepdefs implements En {
     List<Map<String, String>> expectedMaps = dataTable.asMaps(String.class, String.class);
     List<Map<String, String>> actualMaps = new ArrayList<>();
 
-    await().atMost(2, SECONDS).until(() -> {
+    await().atMost(5, SECONDS).until(() -> {
       actualMaps.clear();
       Collections.addAll(actualMaps, retrieveDataMaps(address, dataProcessor));
 

--- a/acceptance-tests/acceptance-pack-spring-demo/src/test/java/org/apache/servicecomb/saga/PackStepdefs.java
+++ b/acceptance-tests/acceptance-pack-spring-demo/src/test/java/org/apache/servicecomb/saga/PackStepdefs.java
@@ -148,7 +148,11 @@ public class PackStepdefs implements En {
     await().atMost(5, SECONDS).until(() -> {
       actualMaps.clear();
       Collections.addAll(actualMaps, retrieveDataMaps(address, dataProcessor));
-
+      // write the log if the Map size is not same
+      boolean result = expectedMaps.size() == actualMaps.size();
+      if (!result) {
+        LOG.warn("The response message size is not we expected. ExpectedMap size is {},  ActualMap size is {}", expectedMaps.size(), actualMaps.size());
+      }
       return expectedMaps.size() == actualMaps.size();
     });
 

--- a/acceptance-tests/acceptance-pack-spring-demo/src/test/resources/booking_exception.btm
+++ b/acceptance-tests/acceptance-pack-spring-demo/src/test/resources/booking_exception.btm
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+##############################################################
+# rules to timeout the booking after invoking the services
+#
+###############################################################
+
+RULE throw exception
+CLASS org.apache.servicecomb.saga.demo.pack.booking.BookingController
+METHOD postCarBooking
+AT ENTRY
+IF TRUE
+DO debug("throw RuntimeException here"),
+   throw new RuntimeException("Cannot access the booking hotel server!")
+ENDRULE

--- a/acceptance-tests/acceptance-pack-spring-demo/src/test/resources/pack_compensation_scenario.feature
+++ b/acceptance-tests/acceptance-pack-spring-demo/src/test/resources/pack_compensation_scenario.feature
@@ -30,8 +30,9 @@ Feature: Alpha records transaction events
       | car     | TxEndedEvent       |
       | hotel   | TxStartedEvent     |
       | hotel   | TxAbortedEvent     |
+      | booking | TxAbortedEvent     |
       | car     | TxCompensatedEvent |
-      | car     | SagaEndedEvent     |
+     
 
     Then Car Service contains the following booking orders
       | name | amount | confirmed | cancelled |

--- a/acceptance-tests/acceptance-pack-spring-demo/src/test/resources/pack_compensation_scenario.feature
+++ b/acceptance-tests/acceptance-pack-spring-demo/src/test/resources/pack_compensation_scenario.feature
@@ -32,8 +32,8 @@ Feature: Alpha records transaction events
       | hotel   | TxAbortedEvent     |
       | booking | TxAbortedEvent     |
       | car     | TxCompensatedEvent |
-     
-
+      | car     | SagaEndedEvent     |
+    
     Then Car Service contains the following booking orders
       | name | amount | confirmed | cancelled |
       | Sean | 5      | false     | true      |

--- a/acceptance-tests/acceptance-pack-spring-demo/src/test/resources/pack_post_car_exception_scenario.feature
+++ b/acceptance-tests/acceptance-pack-spring-demo/src/test/resources/pack_post_car_exception_scenario.feature
@@ -15,28 +15,23 @@
 
 Feature: Alpha records transaction events
 
-  Scenario: A transaction timeout and will be compensated
+  Scenario: An exception is throw and the first transaction should be compensated
     Given Car Service is up and running
     And Hotel Service is up and running
     And Booking Service is up and running
     And Alpha is up and running
 
-    Given Install the byteman script booking_timeout.btm to Booking Service
+    Given Install the byteman script booking_exception.btm to Booking Service
 
     When User Sean requests to book 1 cars and 1 rooms fail
 
     Then Alpha records the following events
-      | serviceName  | type          |
+      | serviceName  | type               |
       | booking | SagaStartedEvent   |
       | car     | TxStartedEvent     |
       | car     | TxEndedEvent       |
-      | hotel   | TxStartedEvent     |
-      | hotel   | TxEndedEvent       |
       | booking | TxAbortedEvent     |
-      | hotel   | TxCompensatedEvent |
       | car     | TxCompensatedEvent |
-      | car     | SagaEndedEvent   |
-
 
     Then Car Service contains the following booking orders
       | name | amount | confirmed | cancelled |
@@ -44,5 +39,4 @@ Feature: Alpha records transaction events
 
     Then Hotel Service contains the following booking orders
       | name | amount | confirmed | cancelled |
-      | Sean | 1      | false     | true      |
-
+    

--- a/alpha/alpha-server/src/main/java/org/apache/servicecomb/saga/alpha/server/AlphaEventController.java
+++ b/alpha/alpha-server/src/main/java/org/apache/servicecomb/saga/alpha/server/AlphaEventController.java
@@ -17,11 +17,14 @@
 
 package org.apache.servicecomb.saga.alpha.server;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 
 import org.apache.servicecomb.saga.alpha.core.TxEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -31,9 +34,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 
+import sun.rmi.runtime.Log;
+
 @Controller
 @RequestMapping("/")
 class AlphaEventController {
+  private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   private final TxEventEnvelopeRepository eventRepository;
 
@@ -43,10 +49,12 @@ class AlphaEventController {
 
   @GetMapping(value = "/events")
   ResponseEntity<Collection<TxEventVo>> events() {
+    LOG.info("Get the events request");
     Iterable<TxEvent> events = eventRepository.findAll();
 
     List<TxEventVo> eventVos = new LinkedList<>();
     events.forEach(event -> eventVos.add(new TxEventVo(event)));
+    LOG.info("Get the event size " + eventVos.size());
 
     return ResponseEntity.ok(eventVos);
   }

--- a/integration-tests/pack-tests/src/test/java/org/apache/servicecomb/saga/integration/pack/tests/PackIT.java
+++ b/integration-tests/pack-tests/src/test/java/org/apache/servicecomb/saga/integration/pack/tests/PackIT.java
@@ -171,15 +171,22 @@ public class PackIT {
     assertThat(txAbortedEvent.serviceName(), is(serviceName));
     assertThat(txAbortedEvent.instanceId(), is(txStartedEvent2.instanceId()));
 
-    // TODO: 2018/1/9 compensation shall be done in reverse order
-    TxEvent txCompensatedEvent1 = events.get(5);
+
+    assertThat(events.get(5).type(), is("TxAbortedEvent"));
+    txAbortedEvent = events.get(5);
+    System.out.println(txAbortedEvent);
+    assertThat(txAbortedEvent.localTxId(), is(globalTxId));
+    assertThat(txAbortedEvent.globalTxId(), is(globalTxId));
+    assertThat(txAbortedEvent.parentTxId(), is(nullValue()));
+    
+    TxEvent txCompensatedEvent1 = events.get(6);
     assertThat(txCompensatedEvent1.type(), is("TxCompensatedEvent"));
     assertThat(txCompensatedEvent1.localTxId(), is(txStartedEvent1.localTxId()));
     assertThat(txCompensatedEvent1.parentTxId(), is(globalTxId));
     assertThat(txCompensatedEvent1.serviceName(), is(serviceName));
     assertThat(txCompensatedEvent1.instanceId(), is(txStartedEvent1.instanceId()));
 
-    assertThat(events.get(6).type(), is("SagaEndedEvent"));
+
 
     assertThat(compensatedMessages, contains("Goodbye, " + TRESPASSER));
   }
@@ -289,8 +296,13 @@ public class PackIT {
     assertThat(events.get(6).type(), is("TxAbortedEvent"));
     assertThat(events.get(7).type(), is("TxStartedEvent"));
     assertThat(events.get(8).type(), is("TxAbortedEvent"));
-    assertThat(events.get(9).type(), is("TxCompensatedEvent"));
-    assertThat(events.get(10).type(), is("SagaEndedEvent"));
+    // This event is for the whole saga event
+    assertThat(events.get(9).type(), is("TxAbortedEvent"));
+    assertThat(events.get(10).type(), is("TxCompensatedEvent"));
+    
+    //assertThat(events.get(10).type(), is("SagaEndedEvent"));
+
+    System.out.println(compensatedMessages);
 
     assertThat(compensatedMessages, contains("Goodbye, " + TRESPASSER));
   }

--- a/omega/omega-transaction/src/main/java/org/apache/servicecomb/saga/omega/transaction/SagaStartAspect.java
+++ b/omega/omega-transaction/src/main/java/org/apache/servicecomb/saga/omega/transaction/SagaStartAspect.java
@@ -58,7 +58,11 @@ public class SagaStartAspect {
 
       return result;
     } catch (Throwable throwable) {
-      LOG.error("Transaction {} failed.", context.globalTxId());
+      // We don't need to handle the OmegaException here
+      if (!(throwable instanceof OmegaException)) {
+        sagaStartAnnotationProcessor.onError(context.globalTxId(), method.toString(), throwable);
+        LOG.error("Transaction {} failed.", context.globalTxId());
+      }
       throw throwable;
     } finally {
       context.clear();

--- a/omega/omega-transaction/src/test/java/org/apache/servicecomb/saga/omega/transaction/SagaStartAspectTest.java
+++ b/omega/omega-transaction/src/test/java/org/apache/servicecomb/saga/omega/transaction/SagaStartAspectTest.java
@@ -100,13 +100,20 @@ public class SagaStartAspectTest {
       assertThat(e, is(oops));
     }
 
-    assertThat(messages.size(), is(1));
+    assertThat(messages.size(), is(2));
     TxEvent event = messages.get(0);
 
     assertThat(event.globalTxId(), is(globalTxId));
     assertThat(event.localTxId(), is(globalTxId));
     assertThat(event.parentTxId(), is(nullValue()));
     assertThat(event.type(), is(EventType.SagaStartedEvent));
+
+    event = messages.get(1);
+    
+    assertThat(event.globalTxId(), is(globalTxId));
+    assertThat(event.localTxId(), is(globalTxId));
+    assertThat(event.parentTxId(), is(nullValue()));
+    assertThat(event.type(), is(EventType.TxAbortedEvent));
 
     assertThat(omegaContext.globalTxId(), is(nullValue()));
     assertThat(omegaContext.localTxId(), is(nullValue()));

--- a/saga-demo/saga-spring-demo/booking/src/main/java/org/apache/servicecomb/saga/demo/pack/booking/BookingController.java
+++ b/saga-demo/saga-spring-demo/booking/src/main/java/org/apache/servicecomb/saga/demo/pack/booking/BookingController.java
@@ -45,6 +45,8 @@ public class BookingController {
         carServiceUrl + "/order/{name}/{cars}",
         null, String.class, name, cars);
 
+    postCarBooking();
+
     template.postForEntity(
         hotelServiceUrl + "/order/{name}/{rooms}",
         null, String.class, name, rooms);
@@ -52,6 +54,11 @@ public class BookingController {
     postBooking();
 
     return name + " booking " + rooms + " rooms and " + cars + " cars OK";
+  }
+
+  // This method is used by the byteman to inject exception here
+  private void postCarBooking() {
+
   }
 
   // This method is used by the byteman to inject the faults such as the timeout or the crash


### PR DESCRIPTION
This TxAbortEvent doesn't have the parent transaction Id, and it's global transaction id and local transaction id is same. 