### PR TITLE
[SCB-785] 支持在补偿方法里得到当前分布式事务的全局事务ID及本地事务ID

### DIFF
--- a/omega/omega-connector/omega-connector-grpc/pom.xml
+++ b/omega/omega-connector/omega-connector-grpc/pom.xml
@@ -39,6 +39,11 @@
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
+      <artifactId>grpc-stub</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
       <artifactId>grpc-netty</artifactId>
     </dependency>
     <dependency>

--- a/omega/omega-spring-starter/src/main/java/org/apache/servicecomb/saga/omega/spring/OmegaSpringConfig.java
+++ b/omega/omega-spring-starter/src/main/java/org/apache/servicecomb/saga/omega/spring/OmegaSpringConfig.java
@@ -52,8 +52,8 @@ class OmegaSpringConfig {
   }
 
   @Bean
-  CompensationContext compensationContext() {
-    return new CompensationContext();
+  CompensationContext compensationContext(OmegaContext omegaContext) {
+    return new CompensationContext(omegaContext);
   }
 
   @Bean

--- a/omega/omega-spring-tx/src/test/java/org/apache/servicecomb/saga/omega/transaction/spring/TransactionInterceptionTest.java
+++ b/omega/omega-spring-tx/src/test/java/org/apache/servicecomb/saga/omega/transaction/spring/TransactionInterceptionTest.java
@@ -361,8 +361,8 @@ public class TransactionInterceptionTest {
     private final List<String> messages = new ArrayList<>();
 
     @Bean
-    CompensationContext recoveryContext() {
-      return new CompensationContext();
+    CompensationContext recoveryContext(OmegaContext omegaContext) {
+      return new CompensationContext(omegaContext);
     }
 
     @Bean

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <akka.version>2.5.6</akka.version>
     <rat.version>0.12</rat.version>
     <maven.failsafe.version>2.19.1</maven.failsafe.version>
-    <grpc.version>1.11.0</grpc.version>
+    <grpc.version>1.14.0</grpc.version>
     <kryo.version>4.0.1</kryo.version>
     <javax.transaction.version>1.2</javax.transaction.version>
     <eclipse.link.version>2.7.1</eclipse.link.version>


### PR DESCRIPTION
1. 补偿方法里通过omegaContext.globalTxId()和omegaContext.localTxId()可得到当前分布式事务的全局事务ID及本地事务ID
2. 解决macOS系统下protoc-gen-grpc-java crash导致无法正常通过maven test的问题，升级依赖的protoc-gen-grpc-java版本，见 https://github.com/grpc/grpc-java/issues/1683
3. 解决protoc-gen-grpc-java无法通过maven
test的问题，补上缺失的grpc-stub依赖

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ x ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SCB) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ x ] Each commit in the pull request should have a meaningful subject line and body.
 - [ x ] Format the pull request title like `[SCB-XXX] Fixes bug in ApproximateQuantiles`, where you replace `SCB-XXX` with the appropriate JIRA issue.
 - [ x ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ x ] Run `mvn clean install` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
