### PR TITLE
[SCB-805] If the node time of alpha and omega are not same, the transaction could be aborted

### DIFF
--- a/alpha/alpha-server/src/main/java/org/apache/servicecomb/saga/alpha/server/GrpcTxEventEndpointImpl.java
+++ b/alpha/alpha-server/src/main/java/org/apache/servicecomb/saga/alpha/server/GrpcTxEventEndpointImpl.java
@@ -78,7 +78,7 @@ class GrpcTxEventEndpointImpl extends TxEventServiceImplBase {
     boolean ok = txConsistentService.handle(new TxEvent(
         message.getServiceName(),
         message.getInstanceId(),
-        new Date(message.getTimestamp()),
+        new Date(),
         message.getGlobalTxId(),
         message.getLocalTxId(),
         message.getParentTxId().isEmpty() ? null : message.getParentTxId(),


### PR DESCRIPTION
If the node time of alpha and omega are not same, the transaction could be aborted.
As the alpha just create the TxEvent which is based on the omega's message timestamp, it could trigger the EventScanner timeout check to abort the transaction. We should use the Alpha timestamp to create the date.

直接使用收到TxEvent的时间作为TxEvent的创建时间，以避免omega与alpha的时间不同步，分布式事务被意外aborted

1. 直接使用收到TxEvent的时间作为TxEvent的创建时间，以避免omega与alpha的时间不同步，分布式事务被意外aborted

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ x ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SCB) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ x ] Each commit in the pull request should have a meaningful subject line and body.
 - [ x ] Format the pull request title like `[SCB-XXX] Fixes bug in ApproximateQuantiles`, where you replace `SCB-XXX` with the appropriate JIRA issue.
 - [ x ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ x ] Run `mvn clean install` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
