### PR TITLE
[SCB-865] Refactoring the Omega Interceptors

### DIFF
--- a/omega/omega-transaction/src/main/java/org/apache/servicecomb/saga/omega/transaction/EventAwareInterceptor.java
+++ b/omega/omega-transaction/src/main/java/org/apache/servicecomb/saga/omega/transaction/EventAwareInterceptor.java
@@ -18,23 +18,9 @@
 package org.apache.servicecomb.saga.omega.transaction;
 
 public interface EventAwareInterceptor {
-  EventAwareInterceptor NO_OP_INTERCEPTOR = new EventAwareInterceptor() {
-    @Override
-    public AlphaResponse preIntercept(String parentTxId, String compensationMethod, int timeout, String retriesMethod,
-        int retries, Object... message) {
-      return new AlphaResponse(false);
-    }
 
-    @Override
-    public void postIntercept(String parentTxId, String compensationMethod) {
-    }
-
-    @Override
-    public void onError(String parentTxId, String compensationMethod, Throwable throwable) {
-    }
-  };
-
-  AlphaResponse preIntercept(String parentTxId, String compensationMethod, int timeout, String retriesMethod,
+  AlphaResponse preIntercept(String parentTxId, String compensationMethod, int timeout,
+      String retriesMethod,
       int retries, Object... message);
 
   void postIntercept(String parentTxId, String compensationMethod);

--- a/omega/omega-transaction/src/main/java/org/apache/servicecomb/saga/omega/transaction/NoOpEventAwareInterceptor.java
+++ b/omega/omega-transaction/src/main/java/org/apache/servicecomb/saga/omega/transaction/NoOpEventAwareInterceptor.java
@@ -1,0 +1,23 @@
+package org.apache.servicecomb.saga.omega.transaction;
+
+public class NoOpEventAwareInterceptor implements EventAwareInterceptor {
+
+  public static final NoOpEventAwareInterceptor INSTANCE = new NoOpEventAwareInterceptor();
+
+  @Override
+  public AlphaResponse preIntercept(String parentTxId, String compensationMethod, int timeout,
+      String retriesMethod,
+      int retries, Object... message) {
+    return new AlphaResponse(false);
+  }
+
+  @Override
+  public void postIntercept(String parentTxId, String compensationMethod) {
+    // NoOp
+  }
+
+  @Override
+  public void onError(String parentTxId, String compensationMethod, Throwable throwable) {
+    // NoOp
+  }
+}

--- a/omega/omega-transaction/src/main/java/org/apache/servicecomb/saga/omega/transaction/SagaStartAnnotationProcessor.java
+++ b/omega/omega-transaction/src/main/java/org/apache/servicecomb/saga/omega/transaction/SagaStartAnnotationProcessor.java
@@ -18,10 +18,9 @@
 package org.apache.servicecomb.saga.omega.transaction;
 
 import javax.transaction.TransactionalException;
-
 import org.apache.servicecomb.saga.omega.context.OmegaContext;
 
-class SagaStartAnnotationProcessor implements EventAwareInterceptor {
+class SagaStartAnnotationProcessor {
 
   private final OmegaContext omegaContext;
   private final MessageSender sender;
@@ -31,27 +30,27 @@ class SagaStartAnnotationProcessor implements EventAwareInterceptor {
     this.sender = sender;
   }
 
-  @Override
-  public AlphaResponse preIntercept(String parentTxId, String compensationMethod, int timeout, String retriesMethod,
-      int retries, Object... message) {
+  AlphaResponse preIntercept(int timeout) {
     try {
-      return sender.send(new SagaStartedEvent(omegaContext.globalTxId(), omegaContext.localTxId(), timeout));
+      return sender
+          .send(new SagaStartedEvent(omegaContext.globalTxId(), omegaContext.localTxId(), timeout));
     } catch (OmegaException e) {
       throw new TransactionalException(e.getMessage(), e.getCause());
     }
   }
 
-  @Override
-  public void postIntercept(String parentTxId, String compensationMethod) {
-    AlphaResponse response = sender.send(new SagaEndedEvent(omegaContext.globalTxId(), omegaContext.localTxId()));
+  void postIntercept(String parentTxId) {
+    AlphaResponse response = sender
+        .send(new SagaEndedEvent(omegaContext.globalTxId(), omegaContext.localTxId()));
     if (response.aborted()) {
       throw new OmegaException("transaction " + parentTxId + " is aborted");
     }
   }
 
-  @Override
-  public void onError(String parentTxId, String compensationMethod, Throwable throwable) {
+  void onError(String parentTxId, String compensationMethod, Throwable throwable) {
     String globalTxId = omegaContext.globalTxId();
-    sender.send(new TxAbortedEvent(globalTxId, omegaContext.localTxId(), null, compensationMethod, throwable));
+    sender.send(
+        new TxAbortedEvent(globalTxId, omegaContext.localTxId(), parentTxId, compensationMethod,
+            throwable));
   }
 }

--- a/omega/omega-transaction/src/main/java/org/apache/servicecomb/saga/omega/transaction/SagaStartAnnotationProcessor.java
+++ b/omega/omega-transaction/src/main/java/org/apache/servicecomb/saga/omega/transaction/SagaStartAnnotationProcessor.java
@@ -47,10 +47,10 @@ class SagaStartAnnotationProcessor {
     }
   }
 
-  void onError(String parentTxId, String compensationMethod, Throwable throwable) {
+  void onError(String compensationMethod, Throwable throwable) {
     String globalTxId = omegaContext.globalTxId();
     sender.send(
-        new TxAbortedEvent(globalTxId, omegaContext.localTxId(), parentTxId, compensationMethod,
+        new TxAbortedEvent(globalTxId, omegaContext.localTxId(), null, compensationMethod,
             throwable));
   }
 }

--- a/omega/omega-transaction/src/main/java/org/apache/servicecomb/saga/omega/transaction/SagaStartAspect.java
+++ b/omega/omega-transaction/src/main/java/org/apache/servicecomb/saga/omega/transaction/SagaStartAspect.java
@@ -59,7 +59,7 @@ public class SagaStartAspect {
     } catch (Throwable throwable) {
       // We don't need to handle the OmegaException here
       if (!(throwable instanceof OmegaException)) {
-        sagaStartAnnotationProcessor.onError(context.globalTxId(), method.toString(), throwable);
+        sagaStartAnnotationProcessor.onError(method.toString(), throwable);
         LOG.error("Transaction {} failed.", context.globalTxId());
       }
       throw throwable;

--- a/omega/omega-transaction/src/main/java/org/apache/servicecomb/saga/omega/transaction/SagaStartAspect.java
+++ b/omega/omega-transaction/src/main/java/org/apache/servicecomb/saga/omega/transaction/SagaStartAspect.java
@@ -19,7 +19,6 @@ package org.apache.servicecomb.saga.omega.transaction;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
-
 import org.apache.servicecomb.saga.omega.context.OmegaContext;
 import org.apache.servicecomb.saga.omega.context.annotations.SagaStart;
 import org.aspectj.lang.ProceedingJoinPoint;
@@ -47,13 +46,13 @@ public class SagaStartAspect {
     initializeOmegaContext();
     Method method = ((MethodSignature) joinPoint.getSignature()).getMethod();
 
-    sagaStartAnnotationProcessor.preIntercept(context.globalTxId(), method.toString(), sagaStart.timeout(), "", 0);
+    sagaStartAnnotationProcessor.preIntercept(sagaStart.timeout());
     LOG.debug("Initialized context {} before execution of method {}", context, method.toString());
 
     try {
       Object result = joinPoint.proceed();
 
-      sagaStartAnnotationProcessor.postIntercept(context.globalTxId(), method.toString());
+      sagaStartAnnotationProcessor.postIntercept(context.globalTxId());
       LOG.debug("Transaction with context {} has finished.", context);
 
       return result;

--- a/omega/omega-transaction/src/test/java/org/apache/servicecomb/saga/omega/transaction/SagaStartAnnotationProcessorTest.java
+++ b/omega/omega-transaction/src/test/java/org/apache/servicecomb/saga/omega/transaction/SagaStartAnnotationProcessorTest.java
@@ -29,9 +29,7 @@ import static org.mockito.Mockito.mock;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-
 import javax.transaction.TransactionalException;
-
 import org.apache.servicecomb.saga.common.EventType;
 import org.apache.servicecomb.saga.omega.context.IdGenerator;
 import org.apache.servicecomb.saga.omega.context.OmegaContext;
@@ -75,9 +73,11 @@ public class SagaStartAnnotationProcessorTest {
   @SuppressWarnings("unchecked")
   private final IdGenerator<String> generator = mock(IdGenerator.class);
   private final OmegaContext context = new OmegaContext(generator);
-  private final OmegaException exception = new OmegaException("exception", new RuntimeException("runtime exception"));
+  private final OmegaException exception = new OmegaException("exception",
+      new RuntimeException("runtime exception"));
 
-  private final SagaStartAnnotationProcessor sagaStartAnnotationProcessor = new SagaStartAnnotationProcessor(context,
+  private final SagaStartAnnotationProcessor sagaStartAnnotationProcessor = new SagaStartAnnotationProcessor(
+      context,
       sender);
 
   @Before
@@ -88,7 +88,7 @@ public class SagaStartAnnotationProcessorTest {
 
   @Test
   public void sendsSagaStartedEvent() {
-    sagaStartAnnotationProcessor.preIntercept(null, null, 0, null, 0);
+    sagaStartAnnotationProcessor.preIntercept(0);
 
     TxEvent event = messages.get(0);
 
@@ -102,7 +102,7 @@ public class SagaStartAnnotationProcessorTest {
 
   @Test
   public void sendsSagaEndedEvent() {
-    sagaStartAnnotationProcessor.postIntercept(null, null);
+    sagaStartAnnotationProcessor.postIntercept(null);
 
     TxEvent event = messages.get(0);
 
@@ -117,12 +117,13 @@ public class SagaStartAnnotationProcessorTest {
   @Test
   public void transformInterceptedException() {
     MessageSender sender = mock(MessageSender.class);
-    SagaStartAnnotationProcessor sagaStartAnnotationProcessor = new SagaStartAnnotationProcessor(context, sender);
+    SagaStartAnnotationProcessor sagaStartAnnotationProcessor = new SagaStartAnnotationProcessor(
+        context, sender);
 
     doThrow(exception).when(sender).send(any(TxEvent.class));
 
     try {
-      sagaStartAnnotationProcessor.preIntercept(null, null, 0, null, 0);
+      sagaStartAnnotationProcessor.preIntercept(0);
       expectFailing(TransactionalException.class);
     } catch (TransactionalException e) {
       assertThat(e.getMessage(), is("exception"));


### PR DESCRIPTION
1.Remove the inheritance hierarchy between SagaStartAnnotationProcessor and EventAwareInterceptor.
2.Remove the NO_OP_INTERCEPTOR from the interface EventAwareInterceptor. Turning the NoOp Implementation into a class of static singleton pattern.
3.Removing parentId when dealing with error.
